### PR TITLE
Fix hostname successfully deleted message being shown when domain wasn't found

### DIFF
--- a/internal/apps/appfile.go
+++ b/internal/apps/appfile.go
@@ -106,11 +106,10 @@ func (appfile *Appfile) Destroy(token string) error {
 		for _, domain := range app.Spec.Domains {
 			if domain.Domain != "" && domain.Zone != "" {
 				log.Debugf("Deleting %s hostname in %s zone", domain.Domain, domain.Zone)
-				err = domainSvc.DeleteRecord(domain.Domain, domain.Zone)
+				err = domainSvc.DeleteRecord(domain)
 				if err != nil {
 					return err
 				}
-				log.Infof("%s hostname deleted successfully from %s zone", domain.Domain, domain.Zone)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

The message `* hostname deleted successfully ...` was being printed when there was a warning that the CNAME wasn't found.

Fixed by moving the message to the `do.domain` service