### PR TITLE
Default values for scope, instance_size_slug, instance_count and kind fields

### DIFF
--- a/internal/apps/app_spec.go
+++ b/internal/apps/app_spec.go
@@ -65,10 +65,6 @@ func (spec *AppSpec) SetDefaultValues() {
 			workerSpec.InstanceSizeSlug = "basic-xxs"
 		}
 	}
-
-	if spec.Region == "" {
-		spec.Region = "nyc"
-	}
 }
 
 func (spec *AppSpec) setEnvVarsDefaults(envs []*godo.AppVariableDefinition) {

--- a/internal/apps/app_spec.go
+++ b/internal/apps/app_spec.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"github.com/digitalocean/godo"
+	"github.com/renehernandez/appfile/internal/log"
 )
 
 type AppSpec struct {
@@ -9,23 +10,71 @@ type AppSpec struct {
 }
 
 func (spec *AppSpec) SetDefaultValues() {
-	if len(spec.StaticSites) > 0 {
-		for _, siteSpec := range spec.StaticSites {
-			if len(siteSpec.Routes) == 0 {
-				siteSpec.Routes = append(siteSpec.Routes, &godo.AppRouteSpec{
-					Path: "/",
-				})
-			}
+	log.Debugf("Setting default values for %s spec", spec.Name)
+	for _, siteSpec := range spec.StaticSites {
+		spec.setEnvVarsDefaults(siteSpec.Envs)
+		if len(siteSpec.Routes) == 0 {
+			siteSpec.Routes = append(siteSpec.Routes, &godo.AppRouteSpec{
+				Path: "/",
+			})
 		}
 	}
 
-	if len(spec.Services) > 0 {
-		for _, svcSpec := range spec.Services {
-			if len(svcSpec.InternalPorts) == 0 && len(svcSpec.Routes) == 0 {
-				svcSpec.Routes = append(svcSpec.Routes, &godo.AppRouteSpec{
-					Path: "/",
-				})
-			}
+	for _, svcSpec := range spec.Services {
+		spec.setEnvVarsDefaults(svcSpec.Envs)
+
+		if svcSpec.InstanceCount == 0 {
+			svcSpec.InstanceCount = 1
+		}
+
+		if svcSpec.InstanceSizeSlug == "" {
+			svcSpec.InstanceSizeSlug = "basic-xxs"
+		}
+
+		if len(svcSpec.InternalPorts) == 0 && len(svcSpec.Routes) == 0 {
+			svcSpec.Routes = append(svcSpec.Routes, &godo.AppRouteSpec{
+				Path: "/",
+			})
+		}
+	}
+
+	for _, jobSpec := range spec.Jobs {
+		spec.setEnvVarsDefaults(jobSpec.Envs)
+
+		if jobSpec.Kind == "" {
+			jobSpec.Kind = "POST_DEPLOY"
+		}
+
+		if jobSpec.InstanceCount == 0 {
+			jobSpec.InstanceCount = 1
+		}
+
+		if jobSpec.InstanceSizeSlug == "" {
+			jobSpec.InstanceSizeSlug = "basic-xxs"
+		}
+	}
+
+	for _, workerSpec := range spec.Workers {
+		spec.setEnvVarsDefaults(workerSpec.Envs)
+
+		if workerSpec.InstanceCount == 0 {
+			workerSpec.InstanceCount = 1
+		}
+
+		if workerSpec.InstanceSizeSlug == "" {
+			workerSpec.InstanceSizeSlug = "basic-xxs"
+		}
+	}
+
+	if spec.Region == "" {
+		spec.Region = "nyc"
+	}
+}
+
+func (spec *AppSpec) setEnvVarsDefaults(envs []*godo.AppVariableDefinition) {
+	for _, envVar := range envs {
+		if envVar.Scope == "" {
+			envVar.Scope = "RUN_AND_BUILD_TIME"
 		}
 	}
 }


### PR DESCRIPTION
## Description

Improves the accuracy of the `diff` operation by configuring default values for the above fields if they are not specified in the local App spec.

Related to https://github.com/digitalocean/godo/issues/419