### PR TITLE
Add list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,14 +20,11 @@ Optionally list components defined in a particular app.
 	listExample = `  # List using defaults: appfile.yaml in current location, default environment and DIGITALOCEAN_ACCESS_TOKEN env var
 appfile list
 
-  # List components for a particular app
-  appfile list <app_name>
-
   # Diff using appfile.yaml in custom location, review environment and access token option
   appfile list --file /path/to/appfile.yaml --environment review --access-token $TOKEN
 
   # List components in app with debug output
-  appfile list <app_name> --log-level debug`
+  appfile list --log-level debug`
 )
 
 func newListCmd(rootCmd *rootCmd) *cobra.Command {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gosuri/uitable"
+	"github.com/renehernandez/appfile/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+type listCmd struct {
+	*rootCmd
+}
+
+var (
+	listLong = `List all apps defined in the appfile.
+
+Optionally list components defined in a particular app.
+`
+	listExample = `  # List using defaults: appfile.yaml in current location, default environment and DIGITALOCEAN_ACCESS_TOKEN env var
+appfile list
+
+  # List components for a particular app
+  appfile list <app_name>
+
+  # Diff using appfile.yaml in custom location, review environment and access token option
+  appfile list --file /path/to/appfile.yaml --environment review --access-token $TOKEN
+
+  # List components in app with debug output
+  appfile list <app_name> --log-level debug`
+)
+
+func newListCmd(rootCmd *rootCmd) *cobra.Command {
+	list := listCmd{
+		rootCmd: rootCmd,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all apps defined in the appfile",
+		Long:    listLong,
+		Example: listExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			list.run()
+		},
+	}
+	return cmd
+}
+
+func (list *listCmd) run() {
+	appfile := list.appfileFromSpec()
+
+	appsStatus, err := appfile.List(list.accessToken)
+	errors.CheckAndFail(err)
+
+	table := uitable.New()
+
+	table.AddRow("NAME", "STATUS", "DEPLOYMENT ID", "UPDATED", "URL")
+	for _, status := range appsStatus {
+		table.AddRow(status.Name, status.Status, status.DeploymentID, status.UpdatedAt, status.URL)
+	}
+	fmt.Println(table)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newDiffCmd(&root))
 	cmd.AddCommand(newSyncCmd(&root))
 	cmd.AddCommand(newDestroyCmd(&root))
+	cmd.AddCommand(newListCmd(&root))
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.2 // indirect
+	github.com/gosuri/uitable v0.0.4
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11
 	github.com/kr/pretty v0.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
+github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -161,6 +163,8 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/internal/apps/app_status.go
+++ b/internal/apps/app_status.go
@@ -1,0 +1,18 @@
+package apps
+
+type AppStatus struct {
+	Name string
+
+	Status       DeploymentStatus
+	DeploymentID string
+	UpdatedAt    string
+	URL          string
+}
+
+type DeploymentStatus string
+
+const (
+	DeploymentStatusUnknown    DeploymentStatus = "unknown"
+	DeploymentStatusDeployed   DeploymentStatus = "deployed"
+	DeploymentStatusInProgress DeploymentStatus = "in progress"
+)


### PR DESCRIPTION
## Description

Fix #17 

The `appfile list` command prints the status information about the App specs in a table format.

### Help

```shell
./dist/appfile_darwin_amd64 list --help
List all apps defined in the appfile.

Optionally list components defined in a particular app.

Usage:
  appfile list [flags]

Examples:
  # List using defaults: appfile.yaml in current location, default environment and DIGITALOCEAN_ACCESS_TOKEN env var
appfile list

  # Diff using appfile.yaml in custom location, review environment and access token option
  appfile list --file /path/to/appfile.yaml --environment review --access-token $TOKEN

  # List components in app with debug output
  appfile list --log-level debug

Flags:
  -h, --help   help for list

Global Flags:
  -t, --access-token string   API V2 access token
  -e, --environment string    root all resources from spec file (default "default")
  -f, --file string           load appfile spec from file (default "appfile.yaml")
      --log-level string      Set log level (default "info")
```