### PR TITLE
Support processing app specification directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ You can leverage `appfile` with your Github Actions workflows, by using `action-
 
 ## Getting Started
 
-Let's look at several app examples and see how `appfile` can help you to manage your App specification and deployments.
+Let's look at an example and see how `appfile` can help you to manage your App specification and deployments.
 
 ## Deploy a web service
 
-This next example deploys an App containing a service definition. The 2 environments: *review* and *production* will customize the final specification of the app to be deployed. Let's look at the `appfile.yaml`, `app.yaml` and environments definitions below.
+This example deploys an App containing a service definition. The 2 environments: *review* and *production* will customize the final specification of the app to be deployed. Let's look at the `appfile.yaml`, `app.yaml` and environments definitions below.
 
 ```yaml
 # appfile.yaml
@@ -130,7 +130,7 @@ services:
     value: Appfile Prod
 ```
 
-To check out more documentation, go to [appfile docs](https://renehernandez.github.io/appfile/latest)
+To learn more about `appfile`, check out the [docs](https://renehernandez.github.io/appfile/latest)
 
 ## Contributing
 

--- a/examples/app.yaml
+++ b/examples/app.yaml
@@ -1,0 +1,11 @@
+name: static-site-from-app-spec
+
+static_sites:
+- environment_slug: html
+  github:
+    branch: main
+    deploy_on_push: true
+    repo: renehernandez/sample-html
+  name: sample-html
+
+region: ams

--- a/examples/static_site/app.yaml
+++ b/examples/static_site/app.yaml
@@ -1,6 +1,6 @@
 name: {{ .Values.spec_name }}
 
-services:
+static_sites:
 - environment_slug: html
   github:
     branch: main

--- a/internal/apps/appfile.go
+++ b/internal/apps/appfile.go
@@ -25,6 +25,18 @@ type Appfile struct {
 	Apps  []*godo.App
 }
 
+func NewAppfileFromAppSpec(spec *AppSpec) (*Appfile, error) {
+	spec.SetDefaultValues()
+
+	return &Appfile{
+		Spec:  &AppfileSpec{},
+		State: &StateData{},
+		Apps: []*godo.App{
+			{Spec: &spec.AppSpec},
+		},
+	}, nil
+}
+
 func NewAppfileFromSpec(spec *AppfileSpec, envName string) (*Appfile, error) {
 	env, err := spec.ReadEnvironment(envName)
 	if err != nil {

--- a/internal/apps/appfile_spec.go
+++ b/internal/apps/appfile_spec.go
@@ -29,6 +29,10 @@ func (spec *AppfileSpec) SetPath(path string) error {
 	return err
 }
 
+func (spec *AppfileSpec) IsValid() bool {
+	return len(spec.AppSpecs) > 0
+}
+
 func (spec *AppfileSpec) hasEnvironment(name string) bool {
 	_, ok := spec.Environments[name]
 	return ok


### PR DESCRIPTION
## Description

Fix #24 

This PR lets `appfile` fallback to process the input file as an App specification, in case is not able to detect the Appfile specification. This helps to onboard new users that may want to leverage some of the features of `appfile` without needing to accommodate for support for environments, etc.

## Changes

* New `NewAppfileFromAppSpec` to create the `Appfile` object based on the already created `App` spec
* Minor fixes in documentation
* Fix App specification for static site in the examples