### PR TITLE
Keep files when pushing redirection update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/redirect
-          keep_files: trues
+          keep_files: true
 
   release_notes:
     name: Create Release Notes


### PR DESCRIPTION
## Description

Pushing the redirect update to the `gh-pages` branch was wiping out existing documentation folders due to incorrect `keep_files` value