### PR TITLE
Fix redirect URL

### DIFF
--- a/docs/scripts/index.html.gotmpl
+++ b/docs/scripts/index.html.gotmpl
@@ -1,3 +1,3 @@
 <head>
-  <meta http-equiv="Refresh" content="0; url='/appfile/{{.}}'" />
+  <meta http-equiv="Refresh" content="0; url='/appfile/{{.}}/'" />
 </head>


### PR DESCRIPTION
## Description

URL redirection is failing due to missing `/` at the end of the URL (e.g. https://renehernandez.github.io/appfile/v0.0.6)